### PR TITLE
fix some compile errors related to references to temporary

### DIFF
--- a/Source/ApprovalBallot.h
+++ b/Source/ApprovalBallot.h
@@ -8,7 +8,7 @@
 class ApprovalBallot : public Ballot
 {
 public:
-	ApprovalBallot(std::vector<bool> &approvals, double weight = 1.0, Random &prng = Random());
+	ApprovalBallot(std::vector<bool> &approvals, double weight, Random &prng);
 
 	void RandomizePrefrences();
 

--- a/Source/Ballot.h
+++ b/Source/Ballot.h
@@ -6,7 +6,7 @@
 class Ballot
 {
 public:
-	Ballot(unsigned candidates = 3, double weight = 1.0, Random &prng = Random());
+	Ballot(unsigned candidates, double weight, Random &prng);
 
 	virtual void RandomizePrefrences() = 0;
 

--- a/Source/OptimalMethod.h
+++ b/Source/OptimalMethod.h
@@ -27,7 +27,7 @@ private:
 	void OnNumSeatsPerWinnerChange();
 	bool _isOutcomeListDirty = true;
 
-	std::vector<Outcome> *_outcomeList;
+	std::vector<Outcome> _outcomeList;
 };
 
 // If I wasn't working in Visual Studios, I would just include all of this code in the cpp file 
@@ -52,7 +52,7 @@ std::vector<Outcome> OptimalMethod<BallotType, QualityValue>::GeneratePosssibleO
 template<typename BallotType, typename QualityValue>
 void OptimalMethod<BallotType, QualityValue>::SetPosssibleOutcomes(int numSeats, bool oneSeatPerWinner)
 {
-	_outcomeList = &GeneratePosssibleOutcomes(numSeats, oneSeatPerWinner);
+	_outcomeList = GeneratePosssibleOutcomes(numSeats, oneSeatPerWinner);
 }
 
 template<typename BallotType, typename QualityValue>
@@ -77,15 +77,14 @@ void OptimalMethod<BallotType, QualityValue>::SetPossibleOutcomes(std::vector<Ou
 	SetNumSeats(maxNumSeats);
 	SetOneSeatPerWinner(oneSeatPerWinner);
 
-	delete _outcomeList;
-	_outcomeList = &possibleOutcomes;
+	_outcomeList = possibleOutcomes;
 	_isOutcomeListDirty = false;
 }
 
 template<typename BallotType, typename QualityValue>
 std::vector<Outcome> &OptimalMethod<BallotType, QualityValue>::GetPossibleOutcomes()
 {
-	return *_outcomeList;
+	return _outcomeList;
 }
 
 template<typename BallotType, typename QualityValue>
@@ -97,7 +96,7 @@ void OptimalMethod<BallotType, QualityValue>::CalculateResults(
 	if (_isOutcomeListDirty)
 		SetPosssibleOutcomes(GetNumSeats(), IsOneSeatPerWinner());
 
-	return CalculateResults(ballots, domain, results, *_outcomeList);
+	return CalculateResults(ballots, domain, results, _outcomeList);
 }
 
 template<typename BallotType, typename QualityValue>

--- a/Source/ScoreBallot.h
+++ b/Source/ScoreBallot.h
@@ -8,7 +8,7 @@
 class ScoreBallot : public Ballot
 {
 public:
-	ScoreBallot(std::vector<double> &scores, double weight = 1.0, Random &prng = Random());
+	ScoreBallot(std::vector<double> &scores, double weight, Random &prng);
 
 	void RandomizePrefrences();
 


### PR DESCRIPTION
- Constructors should not use default arguments because the last argument is a reference.
- There is no reason to make _outcomeList a pointer. Newer compilers can assign vectors very efficiently.